### PR TITLE
Create & use fixture to skip tests if user doesn't have proper configs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 import pytest
 from tellor_disputables.data import get_web3
+from twilio.base.exceptions import TwilioException
+from tellor_disputables.alerts import get_twilio_client
+import warnings
 
 
 @pytest.fixture
@@ -7,4 +10,13 @@ def check_web3_configured() -> None:
     try:
         _ = get_web3(chain_id=1)
     except ValueError as e:
+        warnings.warn(str(e))
+        pytest.skip(str(e))
+
+@pytest.fixture
+def check_twilio_configured() -> None:
+    try:
+        _ = get_twilio_client()
+    except TwilioException as e:
+        warnings.warn(str(e))
         pytest.skip(str(e))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from tellor_disputables.data import get_web3
+
+
+@pytest.fixture
+def check_web3_configured() -> None:
+    try:
+        _ = get_web3(chain_id=1)
+    except ValueError as e:
+        pytest.skip(str(e))

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -27,7 +27,7 @@ def test_get_from_number():
     assert num == "+19035029327"
 
 
-def test_get_twilio_client():
+def test_get_twilio_client(check_twilio_configured):
     client = get_twilio_client()
 
     assert isinstance(client, Client)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -86,7 +86,7 @@ def test_get_query_from_data():
 
 
 @pytest.mark.asyncio
-async def test_rpc_value_errors(caplog):
+async def test_rpc_value_errors(check_web3_configured, caplog):
 
     error_msgs = {
         "{'code': -32000, 'message': 'unknown block'}": "waiting for new blocks",


### PR DESCRIPTION
Closes #32 
- adds `check_web3_configured` fixture to skip `tests/test_data::test_rpc_value_errors` if needed
- adds `check_twilio_configured` fixture to skip `tests/test_alerts::test_get_twiliot_client` if needed

Updated console output:
```console
➜  disputable-values-monitor git:(fix-test-fails-bad-config) poetry run pytest                                                           
========================================================================= test session starts ==========================================================================
platform darwin -- Python 3.10.2, pytest-7.1.1, pluggy-1.0.0
rootdir: /Users/owen/tellor/disputable-values-monitor, configfile: pyproject.toml
plugins: asyncio-0.19.0, web3-5.27.0
asyncio: mode=strict
collected 11 items                                                                                                                                                     

tests/test_alerts.py ..s.                                                                                                                                        [ 36%]
tests/test_data.py ....s                                                                                                                                         [ 81%]
tests/test_utils.py ..                                                                                                                                           [100%]

=========================================================================== warnings summary ===========================================================================
tests/test_alerts.py::test_get_twilio_client
  /Users/owen/tellor/disputable-values-monitor/tests/conftest.py:21: UserWarning: Credentials are required to create a TwilioClient
    warnings.warn(str(e))

tests/test_data.py::test_rpc_value_errors
  /Users/owen/tellor/disputable-values-monitor/tests/conftest.py:13: UserWarning: No API key found. Please set the environment variable INFURA_API_KEY.
    warnings.warn(str(e))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 9 passed, 2 skipped, 2 warnings in 0.73s ===============================================================
➜  disputable-values-monitor git:(fix-test-fails-bad-config) 
```