### PR TITLE
Catch index error when trying to process transaction receipt

### DIFF
--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -179,9 +179,14 @@ def get_tx_receipt(tx_hash: str, web3: Web3, contract: Contract) -> Any:
     try:
         receipt = web3.eth.getTransactionReceipt(tx_hash)
     except TimeoutError:
+        logging.warning(f"timeout getting transaction receipt for {tx_hash}")
         return None
 
-    receipt = contract.events.NewReport().processReceipt(receipt)[0]
+    try:
+        receipt = contract.events.NewReport().processReceipt(receipt)[0]
+    except IndexError:
+        logging.warning(f"Unable to process receipt {str(receipt)}")
+        return None
     return receipt
 
 

--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -185,7 +185,7 @@ def get_tx_receipt(tx_hash: str, web3: Web3, contract: Contract) -> Any:
     try:
         receipt = contract.events.NewReport().processReceipt(receipt)[0]
     except IndexError:
-        logging.warning(f"Unable to process receipt {str(receipt)}")
+        logging.warning(f"Unable to process receipt for transaction {tx_hash}")
         return None
     return receipt
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -115,4 +115,4 @@ def test_get_tx_receipt(check_web3_configured, caplog):
     tx_receipt = get_tx_receipt(w3, tx_hash)
 
     assert tx_receipt is None
-    assert "Unable to process receipt" in caplog.text
+    assert "Unable to process receipt for transaction 0x12345" in caplog.text

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -10,6 +10,7 @@ from tellor_disputables.data import get_query_from_data
 from tellor_disputables.data import get_web3
 from tellor_disputables.data import is_disputable
 from tellor_disputables.data import log_loop
+from tellor_disputables.data import get_tx_receipt
 
 
 @pytest.mark.asyncio
@@ -108,5 +109,10 @@ async def test_rpc_value_errors(check_web3_configured, caplog):
             assert error_msgs[i] in caplog.text
 
 
-def blah():
-    pass
+def test_get_tx_receipt(check_web3_configured, caplog):
+    w3 = get_web3(chain_id=1)
+    tx_hash = "0x12345"
+    tx_receipt = get_tx_receipt(w3, tx_hash)
+
+    assert tx_receipt is None
+    assert "Unable to process receipt" in caplog.text


### PR DESCRIPTION
Closes #29 
- Adds error handling
- Adds a test for that error handling: `tests/test_data.py::test_get_tx_receipt`