### PR TITLE
Fix unable check disputable bug

### DIFF
--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -116,6 +116,10 @@ async def general_fetch_new_datapoint(feed: DataFeed) -> Optional[Any]:
 
 async def is_disputable(reported_val: float, query_id: str, conf_threshold: float = .05) -> Optional[bool]:
     """Check if the reported value is disputable."""
+    if reported_val is None:
+        logging.error("Need reported value to check disputability")
+        return None
+
     if query_id not in DATAFEED_LOOKUP:
         logging.info(f"new report for unsupported query ID: {query_id}")
         return None

--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -109,19 +109,24 @@ async def log_loop(web3: Web3, addr: str) -> list[tuple[int, Any]]:
     return unique_events_list
 
 
-async def is_disputable(reported_val: float, query_id: str, conf_threshold: float) -> Optional[bool]:
+async def general_fetch_new_datapoint(feed: DataFeed) -> Optional[Any]:
+    """Fetch a new datapoint from a datafeed."""
+    return await feed.source.fetch_new_datapoint()
+
+
+async def is_disputable(reported_val: float, query_id: str, conf_threshold: float = .05) -> Optional[bool]:
     """Check if the reported value is disputable."""
     if query_id not in DATAFEED_LOOKUP:
         logging.info(f"new report for unsupported query ID: {query_id}")
         return None
 
     current_feed: DataFeed[Any] = DATAFEED_LOOKUP[query_id]
-    trusted_val: Optional[float] = (await current_feed.source.fetch_new_datapoint())[0]
+    trusted_val, _ = await general_fetch_new_datapoint(current_feed)
     if trusted_val is not None:
         percent_diff = (reported_val - trusted_val) / trusted_val
         return abs(percent_diff) > conf_threshold
     else:
-        logging.error("unable to fetch new datapoint from telliot source")
+        logging.error("Unable to fetch new datapoint from feed")
         return None
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 """Tests for getting & parsing NewReport events."""
+from dis import dis
 from unittest.mock import patch
 
 import pytest
@@ -25,6 +26,14 @@ async def test_is_disputable(caplog):
     disputable = await is_disputable(val, query_id, threshold)
     assert isinstance(disputable, bool)
     assert disputable
+
+    # No reported value
+    disputable = await is_disputable(
+        reported_val=None,
+        query_id=query_id,
+        conf_threshold=threshold)
+    assert disputable is None
+    assert "Need reported value to check disputability" in caplog.text
 
     # Unable to fetch price
     with patch("tellor_disputables.data.general_fetch_new_datapoint", return_value=(None, None)):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -14,19 +14,23 @@ from tellor_disputables.data import get_tx_receipt
 
 
 @pytest.mark.asyncio
-async def test_is_disputable():
+async def test_is_disputable(caplog):
     """test check for disputability for a float value"""
     # ETH/USD
     query_id = "0000000000000000000000000000000000000000000000000000000000000001"
     val = 1000.0
     threshold = 0.05
 
+    # Is disputable
     disputable = await is_disputable(val, query_id, threshold)
-    if not disputable:
-        assert not disputable
-    else:
-        assert isinstance(disputable, bool)
-        assert disputable
+    assert isinstance(disputable, bool)
+    assert disputable
+
+    # Unable to fetch price
+    with patch("tellor_disputables.data.general_fetch_new_datapoint", return_value=(None, None)):
+        disputable = await is_disputable(val, query_id, threshold)
+        assert disputable is None
+        assert "Unable to fetch new datapoint from feed" in caplog.text
 
     # Unsupported query id
     query_id = "gobldygook"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,4 @@
 """Tests for getting & parsing NewReport events."""
-from dis import dis
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
Summary:
This issue reared its ugly head again: #18 
So the only other way this is occurring is if the confidence threshold or return value were `None`, so I put in error handling for no reported value given and set a default value for the confidence threshold.

QA steps:
- Added a test for no reported value in `tests/test_data.py::test_is_disputable` and fixed the test for no trusted value retrieved