### PR TITLE
Downgrades minimum python version to 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CLI dashboard & text alerts app for disputable values reported to Tellor oracl
 ![](demo.gif)
 
 ## Prerequisites:
-- Install Python >= 3.10
+- Install Python 3.9
 - Install [Poetry](https://github.com/python-poetry/poetry)
 - Create an account on [twilio](https://www.twilio.com/docs/sms/quickstart/python)
 
@@ -13,7 +13,7 @@ A CLI dashboard & text alerts app for disputable values reported to Tellor oracl
 - Install dependencies with [Poetry](https://github.com/python-poetry/poetry):
 
 ```
-poetry env use 3.10
+poetry env use 3.9
 poetry install
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ license = "MIT"
 packages = [{ include = "tellor_disputables", from = "src" }]
 
 [tool.poetry.dependencies]
-python = "^3.10.2"
+python = "^3.9.2"
 twilio = "^7.7.0"
-web3 = "5.27.0"
+web3 = "^5.27.0"
 pandas = "^1.4.1"
 tabulate = "^0.8.9"
 pytest-asyncio = "^0.19.0"


### PR DESCRIPTION
Downgrades minimum python version to 3.9 for better websockets support, as the `blockhash_aggregator` import of `telliot-feeds` fails with python 3.10.

Documentation also updated to reflect this change