### PR TITLE
Installs telliot at commit hash that works for DVM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ web3 = "^5.27.0"
 pandas = "^1.4.1"
 tabulate = "^0.8.9"
 pytest-asyncio = "^0.19.0"
-telliot-core = {git = "https://github.com/tellor-io/telliot-core.git", rev = "main"}
-telliot-feeds = {git = "https://github.com/tellor-io/telliot-feeds.git", rev = "main"}
+telliot-core = {git = "https://github.com/tellor-io/telliot-core.git", rev = "a692d532061cef0af59b01c9fb75aca5ac9f7954"}
+telliot-feeds = {git = "https://github.com/tellor-io/telliot-feeds.git", rev = "3a93f98fbfe01f2a2b96cc26d82630cc95b3454f"}
 click = "^8.1.3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This is my temporary fix for the DVM.

Currently `poetry install` will result in a DVM that doesn't work. This is because telliot-feeds and telliot-core dependencies are set to install from their current "mains", which are not compatible with the current main branch of the DVM.

This PR just changes pyproject.toml so that poetry installs the DVM using versions of telliot-feeds and telliot-core that result in a working DVM. 