### PR TITLE
use latest telliot version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ web3 = "^5.27.0"
 pandas = "^1.4.1"
 tabulate = "^0.8.9"
 pytest-asyncio = "^0.19.0"
-telliot-feeds = "0.1.6"
+telliot-feeds = "^0.1.6"
 click = "^8.1.3"
 pydantic = "^1.10.2"
 


### PR DESCRIPTION
Added `^` to specify latest `telliot-feeds` version. Should we also specify latest `telliot-core`? or will that break `telliot-feeds`? @oraclown