### PR TITLE
new release documentation and workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# Per:
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+name: Publish
+
+on:
+  release:
+    types: [published, released]
+
+jobs:
+  build-n-publish:
+    name: Publish tellor-disputables
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@dvm-main
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish tellor-disputables to Test PyPI
+      if: "github.event.release.prerelease"
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TELLOR_DISPUTABES_TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish tellor-disputables to PyPI
+      if: "!github.event.release.prerelease"
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TELLOR_DISPUTABES_PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -104,3 +104,22 @@ Generate requirements.txt in case you have installed new dependencies:
 ```
 poetry export -f requirements.txt --output requirements.txt --without-hashes
 ```
+
+### Publishing a release
+1. Ensure all tests are passing on `dvm-main` branch.
+2. Remove "dev" from version in the `pyproject.toml` file. Example: version = "0.0.5dev" --> version = "0.0.5".
+3. On github, go to "Releases" -> "Draft a new release" -> "Choose a tag".
+4. Write in a new tag that corresponds with the version in `pyproject.toml` file. Example: v0.0.5
+5. If the tag is v.0.0.5, the release title should be Release 0.0.5.
+6. Click Auto-generate release notes.
+7. Check the box for This is a pre-release.
+8. Click Publish release.
+9. Navigate to the Actions tab from the main page of the package on github and make sure the release workflow completes successfully.
+10. Check to make sure the new version was released to test PyPI [here](https://test.pypi.org/project/tellor-disputables/).
+11. Test downloading and using the new version of the package from test PyPI ([example](https://stackoverflow.com/questions/34514703/pip-install-from-pypi-works-but-from-testpypi-fails-cannot-find-requirements)).
+12. Navigate back to the pre-release you just made and click edit (the pencil icon).
+13. Uncheck the This is a pre-release box.
+14. Publish the release.
+15. Make sure the release github action goes through.
+16. Download and test the new release on PyPI official [here](https://pypi.org/project/tellor-disputables/).
+17. Change the package version in **pyproject.toml**.py to be the next development version. For example, if you just released version 0.0.5, change **version** to be "0.0.6dev0".


### PR DESCRIPTION
Closes #98 

The release process is mostly forked from telliot, but it's adjusted for using `poetry` instead of `pip`.