### PR TITLE
unlock account at start of command

### DIFF
--- a/src/tellor_disputables/utils.py
+++ b/src/tellor_disputables/utils.py
@@ -87,6 +87,7 @@ def select_account(cfg: TelliotConfig, account: str) -> Optional[ChainedAccount]
             click.echo("Missing an account to send disputes. Running alerts only!")
             return None
 
+    accounts[0].unlock()
     return accounts[0]
 
 


### PR DESCRIPTION
Previously prompted for password of account at first dispute opportunity, instead it now unlocks the account on startup