### PR TITLE
Parse all chains on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In order to auto-dispute, users need to define what a "disputable value" is. To 
 Ex. If the reported value is 250, and the telliot value is 1000, and the monitoring threshold is a range of 500, then the difference is 750 (it is >= to the range amount of 500), and the value is disputable! Therefore, a reported value of 501, in this case, would **not** be disputable.
 
 ### Percentage
-**Percentage** -- if the difference between the telliot value and the reported value is greater than or equal to a set percentage of the telliot value, dispute! 
+**Percentage** -- if the difference between the telliot value and the reported value is greater than or equal to a set percentage of the telliot value, dispute!
 
 Ex. If the reported value is 250, and the telliot value is 1000, and the percentage threshold is 0.50 (50%), then the percent difference is 75% of the telliot value (1000), and the value is disputable! Therefore, a reported value of 750, in this case, would **not** be disputable.
 

--- a/src/tellor_disputables/utils.py
+++ b/src/tellor_disputables/utils.py
@@ -75,15 +75,15 @@ def select_account(cfg: TelliotConfig, account: Optional[str]) -> Optional[Chain
     """Select an account for disputing, allow no account to be chosen."""
 
     if account is not None:
-        accounts = find_accounts(name=account)  # type: ignore
+        accounts = find_accounts(name=account)
         click.echo(f"Your account name: {accounts[0].name if accounts else None}")
     else:
         add_account = click.confirm("Missing an account to send disputes. Run alerts only?")
         if add_account:
-            account = setup_account(cfg.main.chain_id)
-            if account is not None:
-                click.echo(f"{account.name} selected!")
-                return account
+            new_account = setup_account(cfg.main.chain_id)
+            if new_account is not None:
+                click.echo(f"{new_account.name} selected!")
+                return new_account
             return None
         else:
             return None

--- a/src/tellor_disputables/utils.py
+++ b/src/tellor_disputables/utils.py
@@ -6,9 +6,9 @@ from typing import Optional
 from typing import Union
 
 import click
-from chained_accounts import ChainedAccount, find_accounts
+from chained_accounts import ChainedAccount
+from chained_accounts import find_accounts
 from telliot_core.apps.telliot_config import TelliotConfig
-from telliot_feeds.utils.cfg import check_accounts
 from telliot_feeds.utils.cfg import setup_account
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,12 @@
 """Test helper functions."""
+import os
+from unittest import mock
+from chained_accounts import ChainedAccount, find_accounts
 from telliot_core.apps.telliot_config import TelliotConfig
 
 from src.tellor_disputables import EXAMPLE_NEW_REPORT_EVENT
 from src.tellor_disputables import EXAMPLE_NEW_REPORT_EVENT_TX_RECEIPT
-from src.tellor_disputables.utils import disputable_str
+from src.tellor_disputables.utils import disputable_str, select_account
 from src.tellor_disputables.utils import get_logger
 from src.tellor_disputables.utils import get_tx_explorer_url
 
@@ -41,3 +44,16 @@ def test_logger():
         contents = f.readlines()[-1]
 
     assert "test message that writes to log.txt" in contents
+
+def test_select_account():
+    """test that accounts are not neccesary for running the DVM"""
+
+    cfg = TelliotConfig()
+
+    if not find_accounts("disputer-test-acct"):
+        ChainedAccount.add("disputer-test-acct1", [1, 5, 4, 1337, 80001], os.getenv("PRIVATE_KEY"), "")
+
+    with mock.patch("click.confirm", return_value=False):
+        account = select_account(cfg, None)
+
+    assert not account

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,17 @@
 """Test helper functions."""
 import os
 from unittest import mock
-from chained_accounts import ChainedAccount, find_accounts
+
+from chained_accounts import ChainedAccount
+from chained_accounts import find_accounts
 from telliot_core.apps.telliot_config import TelliotConfig
 
 from src.tellor_disputables import EXAMPLE_NEW_REPORT_EVENT
 from src.tellor_disputables import EXAMPLE_NEW_REPORT_EVENT_TX_RECEIPT
-from src.tellor_disputables.utils import disputable_str, select_account
+from src.tellor_disputables.utils import disputable_str
 from src.tellor_disputables.utils import get_logger
 from src.tellor_disputables.utils import get_tx_explorer_url
+from src.tellor_disputables.utils import select_account
 
 
 def test_get_tx_explorer_url():
@@ -44,6 +47,7 @@ def test_logger():
         contents = f.readlines()[-1]
 
     assert "test message that writes to log.txt" in contents
+
 
 def test_select_account():
     """test that accounts are not neccesary for running the DVM"""


### PR DESCRIPTION
Previously the auto-disputer forced the user to choose an account from the default chain id, now the auto-disputer allows the user to pick from any of their accounts, or decline to pick an account to run disputes only.