### PR TITLE
Catch network is unreachable

### DIFF
--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -279,6 +279,7 @@ async def get_events(
             endpoint.connect()
         except Exception as e:
             logger.warning("unable to connect to endpoint: " + str(e))
+            continue
 
         w3 = endpoint.web3
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -107,6 +107,7 @@ async def test_get_events():
 
     assert len(events) > 0
 
+
 @pytest.mark.asyncio
 async def test_get_events_bad_endpoint_is_skipped(caplog):
 
@@ -118,6 +119,7 @@ async def test_get_events_bad_endpoint_is_skipped(caplog):
 
     assert not events
     assert "unable to connect to endpoint" in caplog.text
+
 
 def test_get_contract_info():
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -107,6 +107,17 @@ async def test_get_events():
 
     assert len(events) > 0
 
+@pytest.mark.asyncio
+async def test_get_events_bad_endpoint_is_skipped(caplog):
+
+    cfg = TelliotConfig()
+
+    cfg.endpoints.endpoints = [RPCEndpoint(1, "Mainnet", "Infura", "badurl.com", "etherscan.io")]
+
+    events = await get_events(cfg, "tellor360-oracle,", [], 0)
+
+    assert not events
+    assert "unable to connect to endpoint" in caplog.text
 
 def test_get_contract_info():
 


### PR DESCRIPTION
Previously bad networks were not skipped when collecting networks to scan for events. Now networks that cannot be connected to will be skipped when trying to retrieve events live from chains