### PR TITLE
Restore universal monitoring

### DIFF
--- a/src/tellor_disputables/cli.py
+++ b/src/tellor_disputables/cli.py
@@ -55,6 +55,7 @@ async def main(all_values: bool, wait: int, account_name: str, is_disputing: boo
 async def start(all_values: bool, wait: int, account_name: str, is_disputing: bool) -> None:
     """Start the CLI dashboard."""
     cfg = TelliotConfig()
+    cfg.main.chain_id = 1
     disp_cfg = AutoDisputerConfig()
     print_title_info()
 
@@ -140,8 +141,8 @@ async def start(all_values: bool, wait: int, account_name: str, is_disputing: bo
 
                 alert(all_values, new_report, recipients, from_number)
 
-                if is_disputing and account and new_report.disputable:
-                    await dispute(cfg, account, new_report)
+                if is_disputing and new_report.disputable:
+                    await dispute(cfg, disp_cfg, account, new_report)
 
                 display_rows.append(
                     (

--- a/src/tellor_disputables/utils.py
+++ b/src/tellor_disputables/utils.py
@@ -78,8 +78,8 @@ def select_account(cfg: TelliotConfig, account: Optional[str]) -> Optional[Chain
         accounts = find_accounts(name=account)
         click.echo(f"Your account name: {accounts[0].name if accounts else None}")
     else:
-        add_account = click.confirm("Missing an account to send disputes. Run alerts only?")
-        if add_account:
+        run_alerts_only = click.confirm("Missing an account to send disputes. Run alerts only?")
+        if not run_alerts_only:
             new_account = setup_account(cfg.main.chain_id)
             if new_account is not None:
                 click.echo(f"{new_account.name} selected!")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -135,7 +135,7 @@ def test_get_contract_info():
 
 
 @pytest.mark.asyncio
-async def test_feed_filter(caplog, log):
+async def test_monitor_all_feeds(caplog, log):
     """test that, if the user wants to monitor only one feed, all other feeds are ignored and skipped"""
 
     caplog.set_level(logging.INFO)
@@ -155,8 +155,8 @@ async def test_feed_filter(caplog, log):
     res = await parse_new_report_event(cfg, monitored_feeds=[monitored_feed], log=log)
 
     # parser should return None
-    assert not res
-    assert "skipping undesired NewReport event" in caplog.text
+    assert res
+    assert not res.disputable
 
     cfg.endpoints.endpoints.remove(endpoint)
 

--- a/tests/test_disputer.py
+++ b/tests/test_disputer.py
@@ -11,6 +11,7 @@ from telliot_core.utils.response import ResponseStatus
 from telliot_feeds.feeds.eth_usd_feed import eth_usd_median_feed
 
 from tellor_disputables import EXAMPLE_NEW_REPORT_EVENT_TX_RECEIPT
+from tellor_disputables.config import AutoDisputerConfig
 from tellor_disputables.data import Metrics
 from tellor_disputables.data import MonitoredFeed
 from tellor_disputables.data import parse_new_report_event
@@ -18,6 +19,34 @@ from tellor_disputables.data import Threshold
 from tellor_disputables.disputer import dispute
 from tellor_disputables.disputer import get_dispute_fee
 from tellor_disputables.utils import NewReport
+
+
+@pytest.mark.asyncio
+async def test_not_meant_to_dispute(caplog, disputer_account):
+    """test when dispute() is called but a dispute is not meant to be sent"""
+
+    report = NewReport(
+        "0xabc123",
+        1679425719,  # this eth block does not have a tellor value on the eth/usd query id
+        1337,
+        "etherscan.io/",
+        "SpotPrice",
+        15.5,
+        "eth",
+        "usd",
+        "0x83a7f3d48786ac2667503a61e8c415438ed2922eb86a2906e4ee66d9a2ce4992",  # eth/usd query id
+        True,
+        "status ",
+    )
+
+    cfg = TelliotConfig()
+    disp_config = AutoDisputerConfig()
+
+    report.query_id = "hi how are you"
+
+    await dispute(cfg, disp_config, account=disputer_account, new_report=report)
+
+    assert "Found disputable new report outside selected Monitored Feeds, skipping dispute" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Restores monitoring of all accessible data feeds, whether or not the user wants to send a dispute on those feeds.

In other words, if the user wants to send disputes on eth/usd, and a reporter submits a disputable btc/usd price, then the monitor will only send an alert, but still measure its disputability.