### PR TITLE
Test multi id disputes

### DIFF
--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        poetry-version: ["1.1.14"]
+        poetry-version: ["1.3.1"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        poetry-version: ["1.1.14"]
+        poetry-version: ["1.3.1"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        poetry-version: ["1.1.14"]
+        poetry-version: ["1.3.1"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/src/tellor_disputables/disputer.py
+++ b/src/tellor_disputables/disputer.py
@@ -115,7 +115,7 @@ async def dispute(
         func_name="beginDispute",
         _queryId=new_report.query_id,
         _timestamp=new_report.submission_timestamp,
-        gas_limit=800000,
+        gas_limit=1000000,
         legacy_gas_price=gas_price,
         acc_nonce=acc_nonce + 1,
     )

--- a/src/tellor_disputables/utils.py
+++ b/src/tellor_disputables/utils.py
@@ -107,3 +107,13 @@ def get_logger(name: str) -> logging.Logger:
     logger.addHandler(fh)
     logger.setLevel(logging.DEBUG)
     return logger
+
+
+def are_all_attributes_none(obj: object) -> bool:
+    """Check if all attributes of an object are None."""
+    if not hasattr(obj, "__dict__"):
+        return False
+    for attr in obj.__dict__:
+        if getattr(obj, attr) is not None:
+            return False
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,20 @@ def setup():
     ganache_endpoint = RPCEndpoint(1337, url="http://localhost:8545")
     cfg.endpoints.endpoints.append(ganache_endpoint)
 
+    w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
+    token = w3.eth.contract(address=token_contract_info.address[1], abi=token_contract_info.get_abi(1))
+    transfer = token.get_function_by_name("transfer")
+    # transfer 100 TRB to the disputer account
+    token_txn = transfer("0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1", int(100e18)).buildTransaction(
+        {
+            "gas": 500000,
+            "gasPrice": w3.eth.gas_price,
+            "nonce": w3.eth.get_transaction_count("0x39E419bA25196794B595B2a595Ea8E527ddC9856"),
+            "from": "0x39E419bA25196794B595B2a595Ea8E527ddC9856",
+        }
+    )
+    w3.eth.send_transaction(token_txn)
+
     yield cfg
 
     del contract_directory.entries["trb-token-fork"], contract_directory.entries["tellor-governance-fork"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 import pytest
@@ -139,6 +140,9 @@ def setup():
     cfg.main.chain_id = 1337
     ganache_endpoint = RPCEndpoint(1337, url="http://localhost:8545")
     cfg.endpoints.endpoints.append(ganache_endpoint)
+    mainnet_endpoint = cfg.endpoints.find(chain_id=1)
+    if mainnet_endpoint and mainnet_endpoint[0].url.endswith("{INFURA_API_KEY}"):
+        mainnet_endpoint[0].url = os.getenv("MAINNET_URL")
 
     w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
     token = w3.eth.contract(address=token_contract_info.address[1], abi=token_contract_info.get_abi(1))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 from hexbytes import HexBytes
 from telliot_core.apps.core import TelliotConfig
 from telliot_core.directory import contract_directory
-from telliot_core.directory import ContractInfo
 from telliot_core.model.endpoints import RPCEndpoint
 from twilio.base.exceptions import TwilioException
 from web3 import Web3
@@ -113,7 +112,7 @@ def check_twilio_configured() -> None:
 
 @pytest.fixture
 def setup():
-
+    """Setup contracts and fork mainnet for testing"""
     token_contract_info = contract_directory.find(name="trb-token", chain_id=1)[0]
     governance_contract_info = contract_directory.find(name="tellor-governance", chain_id=1)[0]
     oracle_contract_info = contract_directory.find(name="tellor360-oracle", chain_id=1)[0]
@@ -122,43 +121,32 @@ def setup():
     contract_directory.entries["tellor360-oracle"].address[1337] = oracle_contract_info.address[1]
     contract_directory.entries["trb-token"].address[1337] = token_contract_info.address[1]
     contract_directory.entries["tellor360-autopay"].address[1337] = autopay_contract_info.address[1]
-
-    forked_token = ContractInfo(
-        "trb-token-fork", "Ganache", {1337: token_contract_info.address[1]}, token_contract_info.abi_file
-    )
-    forked_governance = ContractInfo(
-        "tellor-governance-fork",
-        "Ganache",
-        {1337: governance_contract_info.address[1]},
-        governance_contract_info.abi_file,
-    )
-
-    contract_directory.add_entry(forked_token)
-    contract_directory.add_entry(forked_governance)
+    contract_directory.entries["tellor-governance"].address[1337] = governance_contract_info.address[1]
 
     cfg = TelliotConfig()
     cfg.main.chain_id = 1337
-    ganache_endpoint = RPCEndpoint(1337, url="http://localhost:8545")
+    ganache_endpoint = RPCEndpoint(1337, url="http://127.0.0.1:8545")
     cfg.endpoints.endpoints.append(ganache_endpoint)
     mainnet_endpoint = cfg.endpoints.find(chain_id=1)
     if mainnet_endpoint and mainnet_endpoint[0].url.endswith("{INFURA_API_KEY}"):
         mainnet_endpoint[0].url = os.getenv("MAINNET_URL")
 
-    w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
+    ganache_endpoint.connect()
+    w3 = ganache_endpoint.web3
     token = w3.eth.contract(address=token_contract_info.address[1], abi=token_contract_info.get_abi(1))
     transfer = token.get_function_by_name("transfer")
+    multisig_address = "0x39E419bA25196794B595B2a595Ea8E527ddC9856"
     # transfer 100 TRB to the disputer account
     token_txn = transfer("0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1", int(100e18)).buildTransaction(
         {
             "gas": 500000,
             "gasPrice": w3.eth.gas_price,
-            "nonce": w3.eth.get_transaction_count("0x39E419bA25196794B595B2a595Ea8E527ddC9856"),
-            "from": "0x39E419bA25196794B595B2a595Ea8E527ddC9856",
+            "nonce": w3.eth.get_transaction_count(multisig_address),
+            "from": multisig_address,
         }
     )
     w3.eth.send_transaction(token_txn)
 
     yield cfg
 
-    del contract_directory.entries["trb-token-fork"], contract_directory.entries["tellor-governance-fork"]
     cfg.endpoints.endpoints.remove(ganache_endpoint)

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -130,7 +130,7 @@ async def test_default_config(environment_setup, caplog):
     with patch("getpass.getpass", return_value=""):
         with patch("tellor_disputables.alerts.send_text_msg", side_effect=print("alert sent")):
             with patch("tellor_disputables.cli.TelliotConfig", new=lambda: config):
-                with patch("telliot_feeds.sources.evm_call.EVMCallSource.cfg", config):
+                with patch("telliot_feeds.feeds.evm_call_feed.source.cfg", config):
                     try:
                         async with async_timeout.timeout(9):
                             await start(False, 8, "disputer-test-acct", True, 0.1)

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -140,6 +140,7 @@ async def setup_and_start(config, config_patches=None):
         stack.enter_context(patch("getpass.getpass", return_value=""))
         stack.enter_context(patch("tellor_disputables.alerts.send_text_msg", side_effect=print("alert sent")))
         stack.enter_context(patch("tellor_disputables.cli.TelliotConfig", new=lambda: config))
+        stack.enter_context(patch("telliot_feeds.feeds.evm_call_feed.source.cfg", config))
 
         if config_patches is not None:
             for p in config_patches:

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -1,0 +1,193 @@
+import subprocess
+import time
+from typing import Optional
+from chained_accounts import ChainedAccount
+import pytest
+from telliot_core.apps.core import TelliotConfig
+from web3 import Web3
+from tellor_disputables.cli import start
+from unittest.mock import mock_open, patch
+from telliot_core.apps.core import TelliotCore
+import io
+import async_timeout
+import asyncio
+
+
+wallet = "0x39E419bA25196794B595B2a595Ea8E527ddC9856"
+txn_kwargs = lambda w3: {"gas": 500000, "gasPrice": w3.eth.gas_price, "nonce": w3.eth.get_transaction_count(wallet), "from": wallet}
+eth_query_id = "0x83a7f3d48786ac2667503a61e8c415438ed2922eb86a2906e4ee66d9a2ce4992"
+eth_query_data = "0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000953706f745072696365000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000003657468000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037573640000000000000000000000000000000000000000000000000000000000"
+btc_query_id = "0xa6f013ee236804827b77696d350e9f0ac3e879328f2a3021d473a0b778ad78ac"
+btc_query_data = "0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000953706f745072696365000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000003627463000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037573640000000000000000000000000000000000000000000000000000000000"
+evm_wrong_val = "00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000064528c2b00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000003039"
+evm_query_id = "0xd7472d51b2cd65a9c6b81da09854efdeeeff8afcda1a2934566f54b731a922f3"
+evm_query_data = "0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000745564d43616c6c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000088df592f8eb5d7bd38bfef7deb0fbc02cf3778a00000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000418160ddd00000000000000000000000000000000000000000000000000000000"
+
+
+def custom_open_side_effect(*args, **kwargs):
+    if args[0] == 'disputer-config.yaml':
+        return mock_open().return_value
+    return io.open(*args, **kwargs)
+
+def increase_time_and_mine_blocks(w3: Web3, seconds: int, num_blocks: Optional[int] = None):
+    # Increase time
+    w3.provider.make_request("evm_increaseTime", [seconds])
+
+    # Mine new blocks
+    if num_blocks is None:
+        w3.provider.make_request("evm_mine", [])
+    else:
+        for _ in range(num_blocks):
+            w3.provider.make_request("evm_mine", [])
+
+@pytest.fixture(scope="function")
+async def environment_setup(setup: TelliotConfig, disputer_account: ChainedAccount):
+    config = setup
+    node = config.get_endpoint()
+    node.connect()
+
+    w3 = node._web3
+    increase_time_and_mine_blocks(w3, 600, 20)
+    async with TelliotCore(config=config) as core:
+        account = disputer_account
+        contracts = core.get_tellor360_contracts()
+        oracle = contracts.oracle
+        token = contracts.token
+        approve = token.contract.get_function_by_name("approve")
+        transfer = token.contract.get_function_by_name("transfer")
+        deposit_stake = oracle.contract.get_function_by_name("depositStake")
+        submit_value = oracle.contract.get_function_by_name("submitValue")
+
+        # transfer trb to disputer account for disputing
+        token_txn = transfer(w3.toChecksumAddress(account.address), int(100e18)).buildTransaction(txn_kwargs(w3))
+        token_hash = w3.eth.send_transaction(token_txn)
+        reciept = w3.eth.wait_for_transaction_receipt(token_hash)
+        assert reciept["status"] == 1
+        # approve oracle to spend trb for submitting values
+        approve_txn = approve(oracle.address, int(10000e18)).buildTransaction(txn_kwargs(w3))
+        approve_hash = w3.eth.send_transaction(approve_txn)
+        reciept = w3.eth.wait_for_transaction_receipt(approve_hash)
+        assert reciept["status"] == 1
+        # deposit stake
+        deposit_txn = deposit_stake(_amount=int(10000e18)).buildTransaction(txn_kwargs(w3))
+        deposit_hash = w3.eth.send_transaction(deposit_txn)
+        receipt = w3.eth.wait_for_transaction_receipt(deposit_hash)
+        assert receipt["status"] == 1
+        # submit bad eth value
+        submit_value_txn = submit_value(eth_query_id, int.to_bytes(14,32,'big'), 0, eth_query_data).buildTransaction(txn_kwargs(w3))
+        submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+        receipt = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+        assert receipt["status"] == 1
+        # submit bad btc value
+        # bypass reporter lock
+        increase_time_and_mine_blocks(w3, 4300)
+        submit_value_txn = submit_value(btc_query_id, int.to_bytes(13,32,'big'), 0, btc_query_data).buildTransaction(txn_kwargs(w3))
+        submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+        reciept = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+        assert reciept["status"] == 1
+        # submit bad evmcall value
+        # bypass reporter lock
+        increase_time_and_mine_blocks(w3, 4300)
+        submit_value_txn = submit_value(evm_query_id, evm_wrong_val, 0, evm_query_data).buildTransaction(txn_kwargs(w3))
+        submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+        reciept = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+        assert reciept["status"] == 1
+        return oracle, w3
+
+
+@pytest.mark.asyncio
+async def test_default_config(environment_setup, caplog):
+    oracle, w3 = await environment_setup
+    chain_timestamp = w3.eth.get_block("latest")['timestamp']
+    eth_timestamp, status = await oracle.read("getDataBefore", eth_query_id, chain_timestamp)
+    assert status.ok, status.error
+    evm_timestamp, status = await oracle.read("getDataBefore", evm_query_id, chain_timestamp+5000)
+    assert evm_timestamp[2] > 0
+    assert status.ok, status.error
+    btc_timestamp, status = await oracle.read("getDataBefore", btc_query_id, chain_timestamp+10000)
+    assert btc_timestamp[2] > 0
+    assert status.ok, status.error
+    
+    with patch("getpass.getpass", return_value=""):
+        with patch("tellor_disputables.alerts.send_text_msg", side_effect=print("alert sent")):
+            try:
+                async with async_timeout.timeout(9):
+                    await start(False, 8, "disputer-test-acct", True, 0.1)
+            except asyncio.TimeoutError:
+                pass
+    indispute, _ = await oracle.read("isInDispute", eth_query_id, eth_timestamp[2])
+    assert indispute == True
+    # btc value should not be disputed since not in config
+    indispute, _ = await oracle.read("isInDispute", btc_query_id, btc_timestamp[2])
+    assert indispute == False
+    indispute, _ = await oracle.read("isInDispute", evm_query_id, evm_timestamp[2])
+    # assert indispute == True
+    # An error occurs when trying to read evm call value from telliot source, gets an attribute
+    # error that shouldn't happen, so not sure what's going on here
+    assert "'EVMCallSource' object has no attribute '_history'" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_custom_btc_config(environment_setup):
+    oracle, w3 = await environment_setup
+    chain_timestamp = w3.eth.get_block("latest")['timestamp']
+    eth_timestamp, status = await oracle.read("getDataBefore", eth_query_id, chain_timestamp)
+    assert status.ok, status.error
+    evm_timestamp, status = await oracle.read("getDataBefore", evm_query_id, chain_timestamp+5000)
+    assert evm_timestamp[2] > 0
+    assert status.ok, status.error
+    btc_timestamp, status = await oracle.read("getDataBefore", btc_query_id, chain_timestamp+10000)
+    assert btc_timestamp[2] > 0
+    assert status.ok, status.error
+
+    btc_config = {'feeds': [{'query_id': btc_query_id, 'threshold': {'type': 'Percentage', 'amount': 0.75}}]}
+    with patch("getpass.getpass", return_value=""):
+        with patch("tellor_disputables.alerts.send_text_msg", side_effect=print("alert sent")):
+            with patch('builtins.open', side_effect=custom_open_side_effect):
+                with patch('yaml.safe_load', return_value=btc_config):
+                    try:
+                        async with async_timeout.timeout(7):
+                            await start(False, 8, "disputer-test-acct", True, 0.1)
+                    except asyncio.TimeoutError:
+                        pass
+    indispute, _ = await oracle.read("isInDispute", btc_query_id, btc_timestamp[2])
+    assert indispute == True
+    indispute, _ = await oracle.read("isInDispute", eth_query_id, eth_timestamp[2])
+    assert indispute == False
+    indispute, _ = await oracle.read("isInDispute", evm_query_id, evm_timestamp[2])
+    assert indispute == False
+
+
+@pytest.mark.asyncio
+async def test_custom_eth_btc_config(environment_setup):
+    """Test that eth and btc in dispute config"""
+    oracle, w3 = await environment_setup
+    chain_timestamp = w3.eth.get_block("latest")['timestamp']
+    eth_timestamp, status = await oracle.read("getDataBefore", eth_query_id, chain_timestamp)
+    assert status.ok, status.error
+    evm_timestamp, status = await oracle.read("getDataBefore", evm_query_id, chain_timestamp+5000)
+    assert evm_timestamp[2] > 0
+    assert status.ok, status.error
+    btc_timestamp, status = await oracle.read("getDataBefore", btc_query_id, chain_timestamp+10000)
+    assert btc_timestamp[2] > 0
+    assert status.ok, status.error
+
+    btc_config = {'feeds': [
+        {'query_id': btc_query_id, 'threshold': {'type': 'Percentage', 'amount': 0.75}},
+        {'query_id': eth_query_id, 'threshold': {'type': 'Percentage', 'amount': 0.75}}]
+    }
+    with patch("getpass.getpass", return_value=""):
+        with patch("tellor_disputables.alerts.send_text_msg", side_effect=print("alert sent")):
+            with patch('builtins.open', side_effect=custom_open_side_effect):
+                with patch('yaml.safe_load', return_value=btc_config):
+                    try:
+                        async with async_timeout.timeout(9):
+                            await start(False, 8, "disputer-test-acct", True, 0.1)
+                    except asyncio.TimeoutError:
+                        pass
+    indispute, _ = await oracle.read("isInDispute", btc_query_id, btc_timestamp[2])
+    assert indispute == True
+    indispute, _ = await oracle.read("isInDispute", eth_query_id, eth_timestamp[2])
+    assert indispute == True
+    indispute, _ = await oracle.read("isInDispute", evm_query_id, evm_timestamp[2])
+    assert indispute == False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from telliot_core.apps.telliot_config import TelliotConfig
 
 from src.tellor_disputables import EXAMPLE_NEW_REPORT_EVENT
 from src.tellor_disputables import EXAMPLE_NEW_REPORT_EVENT_TX_RECEIPT
+from src.tellor_disputables.utils import are_all_attributes_none
 from src.tellor_disputables.utils import disputable_str
 from src.tellor_disputables.utils import get_logger
 from src.tellor_disputables.utils import get_tx_explorer_url
@@ -61,3 +62,24 @@ def test_select_account():
         account = select_account(cfg, None)
 
     assert not account
+
+
+class TestObject:
+    def __init__(self, attr1=None, attr2=None, attr3=None):
+        self.attr1 = attr1
+        self.attr2 = attr2
+        self.attr3 = attr3
+
+
+def test_all_attributes_none():
+    obj = TestObject()
+    assert are_all_attributes_none(obj)
+
+
+def test_some_attributes_not_none():
+    obj = TestObject(None, "not none", None)
+    assert not are_all_attributes_none(obj)
+
+
+def test_no_object():
+    assert not are_all_attributes_none("obj")


### PR DESCRIPTION
This pr attempts to use the dispute-config file for auto-disputing queries listed in that file. So if a query is not listed it shouldn't be automatically disputed and vice versa.  Also should auto-dispute all the queries and not only the first item.
Added tests: 
- To show disputing on the default config (has two queries) submit value and auto-dispute for both queries.
- To show only one query in the config file
- To show multiple SpotPrice type queries in config file
- Also manually submitted a bad value for EVMCall type on mumbai and was able to auto-dispute (the evm type wasn't able to check values before so added a fix for this) [txn](https://mumbai.polygonscan.com/tx/0xc8da571810335dfc72636a146a2fe8f58e3f4d56e7b9b7f7b472f8867040caae)