### PR TITLE
Add other query types to be checked

### DIFF
--- a/src/tellor_disputables/__init__.py
+++ b/src/tellor_disputables/__init__.py
@@ -1,59 +1,11 @@
 """Tellor Disputables - CLI dashboard & alerts for potential
 bad values reported to Tellor oracles."""
 from hexbytes import HexBytes
-from telliot_feeds import feeds
-from telliot_feeds.queries.mimicry.nft_market_index import MimicryNFTMarketIndex
-from telliot_feeds.queries.price.spot_price import SpotPrice
 from web3.datastructures import AttributeDict
 
 WAIT_PERIOD = 7  # seconds between checks for new events
 
 ALWAYS_ALERT_QUERY_TYPES = ("AutopayAddresses", "TellorOracleAddress")
-
-QUERY_TYPES = (SpotPrice, MimicryNFTMarketIndex)
-
-DATAFEED_LOOKUP = {
-    "486e2149f25d46bb39a27f5e0c81be9b6f193abf46c0d49314b8d1dd104cd53b": feeds.mimicry_nft_market_index_usd_feed,
-    "0d12ad49193163bbbeff4e6db8294ced23ff8605359fd666799d4e25a3aa0e3a": feeds.ampl_usd_vwap_feed,
-    "35e083af947a4cf3bc053440c3b4f753433c76acab6c8b1911ee808104b72e85": feeds.bct_usd_feed.bct_usd_median_feed,
-    "a6f013ee236804827b77696d350e9f0ac3e879328f2a3021d473a0b778ad78ac": feeds.btc_usd_feed.btc_usd_median_feed,
-    "d913406746edf7891a09ffb9b26a12553bbf4d25ecf8e530ec359969fe6a7a9c": feeds.dai_usd_feed.dai_usd_median_feed,
-    "ba3452d8acca69e530308515f4a0cb01da604dd077801db619800e7d3a7b5f8c": feeds.eth_jpy_feed.eth_jpy_median_feed,
-    "83a7f3d48786ac2667503a61e8c415438ed2922eb86a2906e4ee66d9a2ce4992": feeds.eth_usd_feed.eth_usd_median_feed,
-    "7239909c0aa5d3e89efb2dce06c80811e93ab18413110b8c0435ee32c52cc4fb": feeds.idle_usd_feed.idle_usd_median_feed,
-    "40aa71e5205fdc7bdb7d65f7ae41daca3820c5d3a8f62357a99eda3aa27244a3": feeds.matic_usd_feed.matic_usd_median_feed,
-    "b9d5e25dabd5f0a48f45f5b6b524bac100df05eaf5311f3e5339ac7c3dd0a37e": feeds.mkr_usd_feed.mkr_usd_median_feed,
-    "ee4fcdeed773931af0bcd16cfcea5b366682ffbd4994cf78b4f0a6a40b570340": feeds.olympus.ohm_eth_median_feed,
-    "5c13cd9c97dbb98f2429c101a2a8150e6c7a0ddaff6124ee176a3a411067ded0": feeds.trb_usd_feed.trb_usd_median_feed,
-    "612ec1d9cee860bb87deb6370ed0ae43345c9302c085c1dfc4c207cbec2970d7": feeds.uspce_feed,
-    "2e0aa9e19f5c3e1d3e086b34fe90072b43889382f563e484e8e1e3588b19ef14": feeds.eur_usd_feed.eur_usd_median_feed,
-    "8ee44cd434ed5b0e007eee581fbe0855336f3f84484e8d9989a620a4a49aa0f7": feeds.usdc_usd_feed.usdc_usd_median_feed,
-    "a9b17c33422e2e576fb664d1d11d38c377b614d62f92653d006eca7bb2af1656": feeds.vesq.vsq_usd_median_feed,
-    "6e5122118ce52cc9b97c359c1f174a3c21c71d810f7addce3484cc28e0be0f29": feeds.ric_usd_feed.ric_usd_median_feed,
-    "3f640bf607feb4455c3eb10629385d823341cd18fef6f9f87b8bcfbeafc44eeb": feeds.sushi_usd_feed.sushi_usd_median_feed,
-    "83245f6a6a2f6458558a706270fbcc35ac3a81917602c1313d3bfa998dcc2d4b": feeds.pls_usd_feed,
-    "12906c5e9178631dba86f1f750f7ab7451c61e6357160eb890029b9eac1fb235": feeds.albt_usd_median_feed,
-    "9e1b8afa9d013a06cc4048d1abc5d09b2509a53116db8b3e4a9aad0c88687c8a": feeds.aave_usd_median_feed,
-    "0ea9091cc51722124ea273d517d3d3f7165559e7775e3dc3d086a305bad26e3b": feeds.avax_usd_median_feed,
-    "7ea0d1d673fe38fcdff322c115b0031cdc56696928226701192052c05f00f613": feeds.badger_usd_median_feed,
-    "efa84ae5ea9eb0545e159f78f0a44911ac5a81ecb6ff0c4e32107bcfc66c4baa": feeds.bch_usd_median_feed,
-    "d34bdbc3f48515d7c3be63775e8e5657c5c281c0cf519e7f999b7020ae326b69": feeds.comp_usd_median_feed,
-    "4212eec9815e6acb627893967d9ab4d81a5bd4d4ed24d9e3812ba5c54dce38c6": feeds.crv_usd_median_feed,
-    "15d3cb16e8175919781af07b2ce06714d24f168284b1b47b14b6bfbe9a5a02ff": feeds.doge_usd_median_feed,
-    "8810ffb0cfcb6131da29ed4b229f252d6bac6fc98fc4a61ffbde5b48131e0228": feeds.dot_usd_median_feed,
-    "60723147b1b97df5ff4e69cf99b6a414acc7da119109811af59fe417730945fe": feeds.eth_btc_median_feed,
-    "541e673f520d0d57fa13e38cc510e5e8752005b03030e1d3b843b85f5eb5a411": feeds.eul_usd_median_feed,
-    "537422e5383888586f8f9bca62c5bfd8eb0f8c1bcd335b1a691e6b550c92dcce": feeds.fil_usd_median_feed,
-    "791387543068bca4b983782967bc8e72b80d3e5a5bdf8250796377ec88b227aa": feeds.gno_usd_median_feed,
-    "c138a64c42a40eb5ba8f64de1e62884a0e4259d8c34872c5d5d52a8fa426d697": feeds.link_usd_median_feed,
-    "19585d912afb72378e3986a7a53f1eae1fbae792cd17e1d0df063681326823ae": feeds.ltc_usd_median_feed,
-    "5a81384fbb9313d56e1510a0fd7e51617a796e2d5f8806e4a2f3b4e5d9999617": feeds.rai_usd_median_feed,
-    "a3b64986889b3a1817db443d3846f9af51d6dc3058b13920afb37590f36b9ba1": feeds.shib_usd_median_feed,
-    "b44a64a8c4f1006949b8f471594074e97c5f30ff86acffb2d2a13c00f3aa2da0": feeds.uni_usd_median_feed,
-    "17408737cc4a2657852d14af840811cce2aa3ebb0c9176d2fdfd6abfa9400033": feeds.xdai_usd_median_feed,
-    "c5acb66f4e3e0f6f9e5f52a45ccb9a8b2aef8366bf50f62faaa51248c4f67c41": feeds.yfi_usd_median_feed
-    # "": feeds.diva_protocol_feed.assemble_diva_datafeed
-}
 
 
 # https://goerli.etherscan.io/tx/0x3cb2ac6017b9c2282aba271ac658c55db428edcdd391df646a1928bbe28dd9bd

--- a/src/tellor_disputables/cli.py
+++ b/src/tellor_disputables/cli.py
@@ -193,6 +193,7 @@ async def start(
                     QueryType=query_type,
                     Asset=assets,
                     Currency=currencies,
+                    # split length of characters in the Values' column that overflow when displayed in cli
                     Value=[f"{str(val)[:6]}...{str(val)[-5:]}" if len(str(val)) > 10 else val for val in values],
                     Disputable=disputable_strs,
                     ChainId=chain,

--- a/src/tellor_disputables/cli.py
+++ b/src/tellor_disputables/cli.py
@@ -1,5 +1,4 @@
 """CLI dashboard to display recent values reported to Tellor oracles."""
-import datetime
 import logging
 import warnings
 from time import sleep
@@ -200,9 +199,6 @@ async def start(
                 )
                 df = pd.DataFrame.from_dict(dataframe_state)
                 print(df.to_markdown(), end="\r")
-                now = datetime.datetime.now()
-                print(f"\n\nLast scan: {now.strftime('%H:%M:%S')}")
-                print(f"Next scan: {(now + datetime.timedelta(seconds=wait)).strftime('%H:%M:%S')}", end="\r")
                 df.to_csv("table.csv", mode="a", header=False)
 
         sleep(wait)

--- a/src/tellor_disputables/cli.py
+++ b/src/tellor_disputables/cli.py
@@ -1,4 +1,5 @@
 """CLI dashboard to display recent values reported to Tellor oracles."""
+import datetime
 import logging
 import warnings
 from time import sleep
@@ -175,6 +176,7 @@ async def start(
                         new_report.status_str,
                         new_report.asset,
                         new_report.currency,
+                        new_report.chain_id,
                     )
                 )
 
@@ -184,18 +186,23 @@ async def start(
                     del display_rows[0]
 
                 # Display table
-                _, times, links, _, values, disputable_strs, assets, currencies = zip(*display_rows)
+                _, times, links, query_type, values, disputable_strs, assets, currencies, chain = zip(*display_rows)
+
                 dataframe_state = dict(
                     When=times,
                     Transaction=links,
-                    # QueryType=query_types,
+                    QueryType=query_type,
                     Asset=assets,
                     Currency=currencies,
-                    Value=values,
+                    Value=[f"{str(val)[:6]}...{str(val)[-5:]}" if len(str(val)) > 10 else val for val in values],
                     Disputable=disputable_strs,
+                    ChainId=chain,
                 )
                 df = pd.DataFrame.from_dict(dataframe_state)
                 print(df.to_markdown(), end="\r")
+                now = datetime.datetime.now()
+                print(f"\n\nLast scan: {now.strftime('%H:%M:%S')}")
+                print(f"Next scan: {(now + datetime.timedelta(seconds=wait)).strftime('%H:%M:%S')}", end="\r")
                 df.to_csv("table.csv", mode="a", header=False)
 
         sleep(wait)

--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -19,16 +19,17 @@ from telliot_core.directory import contract_directory
 from telliot_core.model.base import Base
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.datasource import DataSource
+from telliot_feeds.feeds import CATALOG_FEEDS
 from telliot_feeds.feeds import DATAFEED_BUILDER_MAPPING
 from telliot_feeds.queries.abi_query import AbiQuery
 from telliot_feeds.queries.json_query import JsonQuery
 from telliot_feeds.queries.query import OracleQuery
+from telliot_feeds.queries.query_catalog import query_catalog
 from web3 import Web3
 from web3._utils.events import get_event_data
 from web3.types import LogReceipt
 
 from tellor_disputables import ALWAYS_ALERT_QUERY_TYPES
-from tellor_disputables import DATAFEED_LOOKUP
 from tellor_disputables import NEW_REPORT_ABI
 from tellor_disputables import WAIT_PERIOD
 from tellor_disputables.utils import are_all_attributes_none
@@ -442,8 +443,8 @@ async def parse_new_report_event(
 
         if feed_qid == new_report.query_id:
             if new_report.query_type == "SpotPrice":
-
-                mf.feed = DATAFEED_LOOKUP[new_report.query_id[2:]]
+                catalog_entry = query_catalog.find(query_id=new_report.query_id)
+                mf.feed = CATALOG_FEEDS.get(catalog_entry[0].tag)
 
             else:
 
@@ -470,7 +471,31 @@ async def parse_new_report_event(
 
         # build a monitored feed for all feeds not auto-disputing for
         threshold = Threshold(metric=Metrics.Percentage, amount=confidence_threshold)
-        monitored_feed = MonitoredFeed(DATAFEED_LOOKUP[new_report.query_id[2:]], threshold)
+        catalog = query_catalog.find(query_id=new_report.query_id)
+        if catalog:
+            tag = catalog[0].tag
+            feed = CATALOG_FEEDS.get(tag)
+            if feed is None:
+                logger.error(f"Unable to find feed for tag {tag}")
+                return None
+        else:
+            # have to check if feed's source supports generic queries and isn't a manual source
+            # where a manual input is required
+            auto_types = [
+                "GasPriceOracle",
+                "AmpleforthCustomSpotPrice",
+                "AmpleforthUSPCE",
+                "MimicryCollectionStat",
+                "MimicryNFTMarketIndex",
+                "MimicryMacroMarketMashup",
+            ]
+
+            if new_report.query_type not in auto_types:
+                logger.debug(f"Query type {new_report.query_type} doesn't have an auto source to compare value")
+                return None
+            feed = DataFeed(query=q, source=get_source_from_data(event_data.args._queryData))
+
+        monitored_feed = MonitoredFeed(feed, threshold)
 
     disputable = await monitored_feed.is_disputable(cfg, new_report.value)
     if disputable is None:

--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -408,11 +408,13 @@ async def parse_new_report_event(
         return None
 
     new_report.tx_hash = event_data.transactionHash.hex()
-    new_report.chain_id = endpoint.web3.eth.chain_id
+    new_report.chain_id = chain_id
     new_report.query_id = "0x" + event_data.args._queryId.hex()
     new_report.query_type = get_query_type(q)
     new_report.link = get_tx_explorer_url(tx_hash=new_report.tx_hash, cfg=cfg)
     new_report.submission_timestamp = event_data.args._time  # in unix time
+    new_report.asset = getattr(q, "asset", "N/A")
+    new_report.currency = getattr(q, "currency", "N/A")
 
     try:
         new_report.value = q.value_type.decode(event_data.args._value)

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -303,7 +303,7 @@ async def test_custom_spot_type(stake_deposited: Awaitable[TelliotCore]):
     assert receipt["status"] == 1
 
     await setup_and_start(False, config)
-    expected = "Explorer not defined for chain_id 1337,,,1e-18,yes ❗📲"
+    expected = "Explorer not defined for chain_id 1337,AmpleforthCustomSpotPrice,N/A,N/A,1e-18,yes ❗📲"
 
     with open("table.csv", "r") as f:
         lines = f.readlines()
@@ -339,7 +339,7 @@ async def test_gas_oracle_type(stake_deposited: Awaitable[TelliotCore]):
         )
     ]
     await setup_and_start(False, config, config_patches)
-    expected = "Explorer not defined for chain_id 1337,,,46.613,yes ❗📲"
+    expected = "Explorer not defined for chain_id 1337,GasPriceOracle,N/A,N/A,46.613,yes ❗📲"
 
     with open("table.csv", "r") as f:
         lines = f.readlines()

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -276,7 +276,7 @@ async def test_evm_type_alert(submit_multiple_bad_values: Awaitable[TelliotCore]
         patch("yaml.safe_load", return_value=mock_btc_config),
         patch(
             "telliot_feeds.sources.evm_call.EVMCallSource.fetch_new_datapoint",
-            AsyncMock(return_value=(int.to_bytes(2479, 32, "big"), 1679569268)),
+            AsyncMock(return_value=((int.to_bytes(2479, 32, "big"), 1679569268), 0)),
         ),
     ]
     # not disputing just alerting

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -1,15 +1,17 @@
 import asyncio
 import io
 from contextlib import ExitStack
+from typing import Awaitable
 from typing import Optional
+from unittest.mock import AsyncMock
 from unittest.mock import mock_open
 from unittest.mock import patch
 
 import async_timeout
 import pytest
-from chained_accounts import ChainedAccount
 from telliot_core.apps.core import TelliotConfig
 from telliot_core.apps.core import TelliotCore
+from telliot_feeds.feeds import DATAFEED_BUILDER_MAPPING
 from telliot_feeds.feeds import evm_call_feed_example
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from web3 import Web3
@@ -59,7 +61,7 @@ def increase_time_and_mine_blocks(w3: Web3, seconds: int, num_blocks: Optional[i
 
 
 @pytest.fixture(scope="function")
-async def environment_setup(setup: TelliotConfig, disputer_account: ChainedAccount):
+async def environment_setup(setup: TelliotConfig):
     config = setup
     # only configure two required endpoints cause tests take too long
     config.endpoints.endpoints = [config.endpoints.find(chain_id=1)[0], config.endpoints.find(chain_id=1337)[0]]
@@ -69,54 +71,73 @@ async def environment_setup(setup: TelliotConfig, disputer_account: ChainedAccou
     w3 = node._web3
     increase_time_and_mine_blocks(w3, 600, 20)
     async with TelliotCore(config=config) as core:
-        account = disputer_account
         contracts = core.get_tellor360_contracts()
-        oracle = contracts.oracle
-        token = contracts.token
-        approve = token.contract.get_function_by_name("approve")
-        transfer = token.contract.get_function_by_name("transfer")
-        deposit_stake = oracle.contract.get_function_by_name("depositStake")
-        submit_value = oracle.contract.get_function_by_name("submitValue")
-
         # transfer trb to disputer account for disputing
-        token_txn = transfer(w3.toChecksumAddress(account.address), int(100e18)).buildTransaction(txn_kwargs(w3))
-        token_hash = w3.eth.send_transaction(token_txn)
-        reciept = w3.eth.wait_for_transaction_receipt(token_hash)
-        assert reciept["status"] == 1
-        # approve oracle to spend trb for submitting values
-        approve_txn = approve(oracle.address, int(10000e18)).buildTransaction(txn_kwargs(w3))
-        approve_hash = w3.eth.send_transaction(approve_txn)
-        reciept = w3.eth.wait_for_transaction_receipt(approve_hash)
-        assert reciept["status"] == 1
-        # deposit stake
-        deposit_txn = deposit_stake(_amount=int(10000e18)).buildTransaction(txn_kwargs(w3))
-        deposit_hash = w3.eth.send_transaction(deposit_txn)
-        receipt = w3.eth.wait_for_transaction_receipt(deposit_hash)
-        assert receipt["status"] == 1
-        # submit bad eth value
-        submit_value_txn = submit_value(eth_query_id, int.to_bytes(14, 32, "big"), 0, eth_query_data).buildTransaction(
+        token = contracts.token
+        account = token.account
+        transfer_function = contracts.token.contract.get_function_by_name("transfer")
+        transfer_txn = transfer_function(w3.toChecksumAddress(account.address), int(100e18)).buildTransaction(
             txn_kwargs(w3)
         )
-        submit_value_hash = w3.eth.send_transaction(submit_value_txn)
-        receipt = w3.eth.wait_for_transaction_receipt(submit_value_hash)
-        assert receipt["status"] == 1
-        # submit bad btc value
-        # bypass reporter lock
-        increase_time_and_mine_blocks(w3, 4300)
-        submit_value_txn = submit_value(btc_query_id, int.to_bytes(13, 32, "big"), 0, btc_query_data).buildTransaction(
-            txn_kwargs(w3)
-        )
-        submit_value_hash = w3.eth.send_transaction(submit_value_txn)
-        reciept = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+        transfer_hash = w3.eth.send_transaction(transfer_txn)
+        reciept = w3.eth.wait_for_transaction_receipt(transfer_hash)
         assert reciept["status"] == 1
-        # submit bad evmcall value
-        # bypass reporter lock
-        increase_time_and_mine_blocks(w3, 4300)
-        submit_value_txn = submit_value(evm_query_id, evm_wrong_val, 0, evm_query_data).buildTransaction(txn_kwargs(w3))
-        submit_value_hash = w3.eth.send_transaction(submit_value_txn)
-        reciept = w3.eth.wait_for_transaction_receipt(submit_value_hash)
-        assert reciept["status"] == 1
-        return config, oracle, w3
+        return core
+
+
+@pytest.fixture(scope="function")
+async def stake_deposited(environment_setup: TelliotCore):
+    core = await environment_setup
+    contracts = core.get_tellor360_contracts()
+    w3 = core.endpoint._web3
+    oracle = contracts.oracle
+    token = contracts.token
+    approve = token.contract.get_function_by_name("approve")
+    deposit = oracle.contract.get_function_by_name("depositStake")
+    # approve oracle to spend trb for submitting values
+    approve_txn = approve(oracle.address, int(10000e18)).buildTransaction(txn_kwargs(w3))
+    approve_hash = w3.eth.send_transaction(approve_txn)
+    reciept = w3.eth.wait_for_transaction_receipt(approve_hash)
+    assert reciept["status"] == 1
+    # deposit stake
+    deposit_txn = deposit(_amount=int(10000e18)).buildTransaction(txn_kwargs(w3))
+    deposit_hash = w3.eth.send_transaction(deposit_txn)
+    receipt = w3.eth.wait_for_transaction_receipt(deposit_hash)
+    assert receipt["status"] == 1
+    return core
+
+
+@pytest.fixture(scope="function")
+async def submit_multiple_bad_values(stake_deposited: Awaitable[TelliotCore]):
+    core = await stake_deposited
+    contracts = core.get_tellor360_contracts()
+    w3 = core.endpoint._web3
+    oracle = contracts.oracle
+    submit_value = oracle.contract.get_function_by_name("submitValue")
+    # submit bad eth value
+    submit_value_txn = submit_value(eth_query_id, int.to_bytes(14, 32, "big"), 0, eth_query_data).buildTransaction(
+        txn_kwargs(w3)
+    )
+    submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+    receipt = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+    assert receipt["status"] == 1
+    # submit bad btc value
+    # bypass reporter lock
+    increase_time_and_mine_blocks(w3, 4300)
+    submit_value_txn = submit_value(btc_query_id, int.to_bytes(13, 32, "big"), 0, btc_query_data).buildTransaction(
+        txn_kwargs(w3)
+    )
+    submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+    reciept = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+    assert reciept["status"] == 1
+    # submit bad evmcall value
+    # bypass reporter lock
+    increase_time_and_mine_blocks(w3, 4300)
+    submit_value_txn = submit_value(evm_query_id, evm_wrong_val, 0, evm_query_data).buildTransaction(txn_kwargs(w3))
+    submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+    reciept = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+    assert reciept["status"] == 1
+    return core
 
 
 @pytest.mark.asyncio
@@ -134,7 +155,7 @@ async def check_dispute(oracle, query_id, timestamp):
     return indispute
 
 
-async def setup_and_start(config, config_patches=None):
+async def setup_and_start(is_disputing, config, config_patches=None):
     # using exit stack makes nested patching easier to read
     with ExitStack() as stack:
         stack.enter_context(patch("getpass.getpass", return_value=""))
@@ -148,22 +169,25 @@ async def setup_and_start(config, config_patches=None):
 
         try:
             async with async_timeout.timeout(9):
-                await start(False, 8, "disputer-test-acct", True, 0.1)
+                await start(False, 8, "disputer-test-acct", is_disputing, 0.1)
         except asyncio.TimeoutError:
             pass
 
 
 @pytest.mark.asyncio
-async def test_default_config(environment_setup):
+async def test_default_config(submit_multiple_bad_values: Awaitable[TelliotCore]):
     """Test that the default config works as expected"""
-    config, oracle, w3 = await environment_setup
+    core = await submit_multiple_bad_values
+    config = core.config
+    oracle = core.get_tellor360_contracts().oracle
+    w3 = core.endpoint._web3
     chain_timestamp = w3.eth.get_block("latest")["timestamp"]
 
     eth_timestamp = await fetch_timestamp(oracle, eth_query_id, chain_timestamp)
     evm_timestamp = await fetch_timestamp(oracle, evm_query_id, chain_timestamp + 5000)
     btc_timestamp = await fetch_timestamp(oracle, btc_query_id, chain_timestamp + 10000)
 
-    await setup_and_start(config)
+    await setup_and_start(True, config)
     # not in config file
     assert not await check_dispute(oracle, btc_query_id, btc_timestamp)
     # in config file
@@ -172,9 +196,12 @@ async def test_default_config(environment_setup):
 
 
 @pytest.mark.asyncio
-async def test_custom_btc_config(environment_setup):
+async def test_custom_btc_config(submit_multiple_bad_values: Awaitable[TelliotCore]):
     """Test that a custom btc config works as expected"""
-    config, oracle, w3 = await environment_setup
+    core = await submit_multiple_bad_values
+    config = core.config
+    oracle = core.get_tellor360_contracts().oracle
+    w3 = core.endpoint._web3
     chain_timestamp = w3.eth.get_block("latest")["timestamp"]
 
     eth_timestamp = await fetch_timestamp(oracle, eth_query_id, chain_timestamp)
@@ -186,7 +213,7 @@ async def test_custom_btc_config(environment_setup):
         patch("builtins.open", side_effect=custom_open_side_effect),
         patch("yaml.safe_load", return_value=btc_config),
     ]
-    await setup_and_start(config, config_patches)
+    await setup_and_start(True, config, config_patches)
 
     assert await check_dispute(oracle, btc_query_id, btc_timestamp)
     # not in config file
@@ -195,9 +222,12 @@ async def test_custom_btc_config(environment_setup):
 
 
 @pytest.mark.asyncio
-async def test_custom_eth_btc_config(environment_setup):
+async def test_custom_eth_btc_config(submit_multiple_bad_values: Awaitable[TelliotCore]):
     """Test that eth and btc in dispute config"""
-    config, oracle, w3 = await environment_setup
+    core = await submit_multiple_bad_values
+    config = core.config
+    oracle = core.get_tellor360_contracts().oracle
+    w3 = core.endpoint._web3
     chain_timestamp = w3.eth.get_block("latest")["timestamp"]
 
     eth_timestamp = await fetch_timestamp(oracle, eth_query_id, chain_timestamp)
@@ -214,7 +244,7 @@ async def test_custom_eth_btc_config(environment_setup):
         patch("builtins.open", side_effect=custom_open_side_effect),
         patch("yaml.safe_load", return_value=btc_eth_config),
     ]
-    await setup_and_start(config, config_patches)
+    await setup_and_start(True, config, config_patches)
 
     assert await check_dispute(oracle, btc_query_id, btc_timestamp)
     assert await check_dispute(oracle, eth_query_id, eth_timestamp)
@@ -223,12 +253,94 @@ async def test_custom_eth_btc_config(environment_setup):
 
 
 @pytest.mark.asyncio
-async def test_get_source_from_data(environment_setup, caplog):
+async def test_get_source_from_data(submit_multiple_bad_values: Awaitable[TelliotCore], caplog):
     """Test when get_source_from_data function returns None"""
-    config, _, _ = await environment_setup
+    core = await submit_multiple_bad_values
+    config = core.config
 
     config_patches = [
         patch("tellor_disputables.data.get_source_from_data", side_effect=lambda _: None),
     ]
-    await setup_and_start(config, config_patches)
+    await setup_and_start(True, config, config_patches)
     assert "Unable to form source from queryData of query type EVMCall" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_evm_type_alert(submit_multiple_bad_values: Awaitable[TelliotCore], caplog):
+    """Test when evm type alert is triggered should display message that difference can't be evaluated"""
+    core = await submit_multiple_bad_values
+    config = core.config
+    # dispute config requires at least 1 item
+    mock_btc_config = {"feeds": [{"query_id": btc_query_id, "threshold": {"type": "Percentage", "amount": 0.75}}]}
+    config_patches = [
+        patch("builtins.open", side_effect=custom_open_side_effect),
+        patch("yaml.safe_load", return_value=mock_btc_config),
+    ]
+    # not disputing just alerting
+    # if evm type is in dispute config it will be checked for equality
+    await setup_and_start(False, config, config_patches)
+    assert "Cannot evaluate percent difference on text/addresses/bytes" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_custom_spot_type(stake_deposited: Awaitable[TelliotCore]):
+    core = await stake_deposited
+    contracts = core.get_tellor360_contracts()
+    w3 = core.endpoint._web3
+    oracle = contracts.oracle
+    config = core.config
+    feed = DATAFEED_BUILDER_MAPPING["AmpleforthCustomSpotPrice"]
+    qid = Web3.toHex(feed.query.query_id)
+    qdata = Web3.toHex(feed.query.query_data)
+    submit_value = oracle.contract.get_function_by_name("submitValue")
+    # submit bad ampl value, and check if alert; ampl is a custom type and a SpotPrice type
+    submit_value_txn = submit_value(qid, int.to_bytes(1, 32, "big"), 0, qdata).buildTransaction(txn_kwargs(w3))
+    submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+    receipt = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+    assert receipt["status"] == 1
+
+    await setup_and_start(False, config)
+    expected = "Explorer not defined for chain_id 1337,,,1e-18,yes ❗📲"
+
+    with open("table.csv", "r") as f:
+        lines = f.readlines()
+        # get the last row
+        last_row = lines[-1]
+
+        assert expected in last_row
+
+
+@pytest.mark.asyncio
+async def test_gas_oracle_type(stake_deposited: Awaitable[TelliotCore]):
+    core = await stake_deposited
+    contracts = core.get_tellor360_contracts()
+    w3 = core.endpoint._web3
+    oracle = contracts.oracle
+    config = core.config
+    feed = DATAFEED_BUILDER_MAPPING["GasPriceOracle"]
+    feed.query.chainId = 1
+    feed.query.timestamp = 1679569268
+    qid = Web3.toHex(feed.query.query_id)
+    qdata = Web3.toHex(feed.query.query_data)
+    val = Web3.toHex(feed.query.value_type.encode(46.613))
+    submit_value = oracle.contract.get_function_by_name("submitValue")
+
+    submit_value_txn = submit_value(qid, val, 0, qdata).buildTransaction(txn_kwargs(w3))
+    submit_value_hash = w3.eth.send_transaction(submit_value_txn)
+    receipt = w3.eth.wait_for_transaction_receipt(submit_value_hash)
+    assert receipt["status"] == 1
+    config_patches = [
+        patch(
+            "telliot_feeds.sources.gas_price_oracle.GasPriceOracleSource.fetch_new_datapoint",
+            AsyncMock(return_value=(22.5, 1679569268)),
+        )
+    ]
+    await setup_and_start(False, config, config_patches)
+    expected = "Explorer not defined for chain_id 1337,,,46.613,yes ❗📲"
+
+    with open("table.csv", "r") as f:
+        lines = f.readlines()
+        # get the last row
+        last_row = lines[-1]
+
+        assert expected in last_row


### PR DESCRIPTION
Add the ability check non spotprice types for alerting whenever difference can be calculated also fetches feed dynamically from telliot feeds (Closes #125).
Change how EVMCall response is compared, use value and disregard timestamp