### PR TITLE
Enhance DVM to start search from earlier blocks

### DIFF
--- a/src/tellor_disputables/cli.py
+++ b/src/tellor_disputables/cli.py
@@ -21,6 +21,7 @@ from tellor_disputables.data import get_events
 from tellor_disputables.data import parse_new_report_event
 from tellor_disputables.disputer import dispute
 from tellor_disputables.utils import clear_console
+from tellor_disputables.utils import format_values
 from tellor_disputables.utils import get_logger
 from tellor_disputables.utils import get_tx_explorer_url
 from tellor_disputables.utils import select_account
@@ -178,6 +179,8 @@ async def start(
 
                 # Prune display
                 if len(display_rows) > 10:
+                    # sort by timestamp
+                    display_rows = sorted(display_rows, key=lambda x: x[1])
                     displayed_events.remove(display_rows[0][0])
                     del display_rows[0]
 
@@ -191,13 +194,17 @@ async def start(
                     Asset=assets,
                     Currency=currencies,
                     # split length of characters in the Values' column that overflow when displayed in cli
-                    Value=[f"{str(val)[:6]}...{str(val)[-5:]}" if len(str(val)) > 10 else val for val in values],
+                    Value=values,
                     Disputable=disputable_strs,
                     ChainId=chain,
                 )
                 df = pd.DataFrame.from_dict(dataframe_state)
-                print(df.to_markdown(), end="\r")
+                df = df.sort_values("When")
+                df["Value"] = df["Value"].apply(format_values)
+                print(df.to_markdown(index=False), end="\r")
                 df.to_csv("table.csv", mode="a", header=False)
+                # reset config to clear object attributes that were set during loop
+                disp_cfg = AutoDisputerConfig()
 
         sleep(wait)
 

--- a/src/tellor_disputables/cli.py
+++ b/src/tellor_disputables/cli.py
@@ -100,13 +100,11 @@ async def start(
             cfg=cfg,
             contract_name="tellor360-oracle",
             topics=[Topics.NEW_REPORT],
-            wait=wait,
         )
         tellor_flex_report_events = await get_events(
             cfg=cfg,
             contract_name="tellorflex-oracle",
             topics=[Topics.NEW_REPORT],
-            wait=wait,
         )
         tellor360_events = await chain_events(
             cfg=cfg,
@@ -116,7 +114,6 @@ async def start(
                 5: "0x51c59c6cAd28ce3693977F2feB4CfAebec30d8a2",
             },
             topics=[[Topics.NEW_ORACLE_ADDRESS], [Topics.NEW_PROPOSED_ORACLE_ADDRESS]],
-            wait=wait,
         )
         event_lists += tellor360_events + tellor_flex_report_events
         for event_list in event_lists:

--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -4,6 +4,7 @@ import math
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -31,7 +32,6 @@ from web3.types import LogReceipt
 
 from tellor_disputables import ALWAYS_ALERT_QUERY_TYPES
 from tellor_disputables import NEW_REPORT_ABI
-from tellor_disputables import WAIT_PERIOD
 from tellor_disputables.utils import are_all_attributes_none
 from tellor_disputables.utils import disputable_str
 from tellor_disputables.utils import get_logger
@@ -45,6 +45,10 @@ class Metrics(Enum):
     Percentage = "percentage"
     Equality = "equality"
     Range = "range"
+
+
+start_block: Dict[int, int] = {}
+inital_block_offset = 1000
 
 
 @dataclass
@@ -251,11 +255,8 @@ def mk_filter(
     }
 
 
-async def log_loop(web3: Web3, chain_id: int, addr: str, topics: list[str], wait: int) -> list[tuple[int, Any]]:
+async def log_loop(web3: Web3, chain_id: int, addr: str, topics: list[str]) -> list[tuple[int, Any]]:
     """Generate a list of recent events from a contract."""
-    # go back 20 blocks; 10 for possible reorgs, the other 10 should cover for even the fastest chains. block/sec
-    # 1000 is the max number of blocks that can be queried at once
-    blocks = min(20 * (wait / WAIT_PERIOD), 1000)
     try:
         block_number = web3.eth.get_block_number()
     except Exception as e:
@@ -264,8 +265,9 @@ async def log_loop(web3: Web3, chain_id: int, addr: str, topics: list[str], wait
         else:
             logger.warning(f"unable to retrieve latest block number from chain_id {chain_id}: {e}")
         return []
-
-    event_filter = mk_filter(block_number - int(blocks), block_number, addr, topics)
+    from_block = start_block.get(chain_id, block_number - inital_block_offset)
+    from_block -= 10  # go back 10 more blocks to account for reorgs
+    event_filter = mk_filter(from_block, block_number, addr, topics)
 
     try:
         events = web3.eth.get_logs(event_filter)  # type: ignore
@@ -285,12 +287,12 @@ async def log_loop(web3: Web3, chain_id: int, addr: str, topics: list[str], wait
     for event in events:
         if (chain_id, event) not in unique_events_list:
             unique_events_list.append((chain_id, event))
-
+    start_block[chain_id] = block_number
     return unique_events_list
 
 
 async def chain_events(
-    cfg: TelliotConfig, chain_addy: dict[int, str], topics: list[list[str]], wait: int
+    cfg: TelliotConfig, chain_addy: dict[int, str], topics: list[list[str]]
 ) -> List[List[tuple[int, Any]]]:
     """"""
     events_loop = []
@@ -305,15 +307,13 @@ async def chain_events(
             except (IndexError, ValueError) as e:
                 logger.error(f"Unable to connect to endpoint on chain_id {chain_id}: {e}")
                 continue
-            events_loop.append(log_loop(w3, chain_id, address, topic, wait))
+            events_loop.append(log_loop(w3, chain_id, address, topic))
     events: List[List[tuple[int, Any]]] = await asyncio.gather(*events_loop)
 
     return events
 
 
-async def get_events(
-    cfg: TelliotConfig, contract_name: str, topics: list[str], wait: int
-) -> List[List[tuple[int, Any]]]:
+async def get_events(cfg: TelliotConfig, contract_name: str, topics: list[str]) -> List[List[tuple[int, Any]]]:
     """Get all events from all live Tellor networks"""
 
     log_loops = []
@@ -338,7 +338,7 @@ async def get_events(
         if not addr:
             continue
 
-        log_loops.append(log_loop(w3, chain_id, addr, topics, wait))
+        log_loops.append(log_loop(w3, chain_id, addr, topics))
 
     events_lists: List[List[tuple[int, Any]]] = await asyncio.gather(*log_loops)
 

--- a/src/tellor_disputables/utils.py
+++ b/src/tellor_disputables/utils.py
@@ -2,6 +2,8 @@
 import logging
 import os
 from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
 from typing import Optional
 from typing import Union
 
@@ -117,3 +119,13 @@ def are_all_attributes_none(obj: object) -> bool:
         if getattr(obj, attr) is not None:
             return False
     return True
+
+
+def format_values(val: Any) -> Any:
+    """shorten values for cli display"""
+    if isinstance(val, float):
+        return Decimal(f"{val:.4f}")
+    elif len(str(val)) > 10:
+        return f"{str(val)[:6]}...{str(val)[-5:]}"
+    else:
+        return val

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -17,8 +17,10 @@ from telliot_feeds.feeds import evm_call_feed_example
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from web3 import Web3
 
+from tellor_disputables import data
 from tellor_disputables.cli import start
-
+# during testing there aren't that many blocks so setting offset to 0
+data.inital_block_offset = 0
 # mainnet wallet used for testing
 wallet = "0x39E419bA25196794B595B2a595Ea8E527ddC9856"
 

--- a/tests/test_auto_dispute_multiple_ids.py
+++ b/tests/test_auto_dispute_multiple_ids.py
@@ -19,6 +19,7 @@ from web3 import Web3
 
 from tellor_disputables import data
 from tellor_disputables.cli import start
+
 # during testing there aren't that many blocks so setting offset to 0
 data.inital_block_offset = 0
 # mainnet wallet used for testing
@@ -305,7 +306,7 @@ async def test_custom_spot_type(stake_deposited: Awaitable[TelliotCore]):
     assert receipt["status"] == 1
 
     await setup_and_start(False, config)
-    expected = "Explorer not defined for chain_id 1337,AmpleforthCustomSpotPrice,N/A,N/A,1e-18,yes ❗📲"
+    expected = "Explorer not defined for chain_id 1337,AmpleforthCustomSpotPrice,N/A,N/A,0.0000,yes ❗📲"
 
     with open("table.csv", "r") as f:
         lines = f.readlines()
@@ -341,7 +342,7 @@ async def test_gas_oracle_type(stake_deposited: Awaitable[TelliotCore]):
         )
     ]
     await setup_and_start(False, config, config_patches)
-    expected = "Explorer not defined for chain_id 1337,GasPriceOracle,N/A,N/A,46.613,yes ❗📲"
+    expected = "Explorer not defined for chain_id 1337,GasPriceOracle,N/A,N/A,46.6130,yes ❗📲"
 
     with open("table.csv", "r") as f:
         lines = f.readlines()


### PR DESCRIPTION
- Start search 1k blocks back and maintain a from block - 10, to start each scan from
- Fix showing events for query types such as EVMCall, was one showing one instead of all
- Sort displayed events by timestamp
- Inject geth_poa_middleware when scanning Sepolia(poa chain) when calling get_block (required for evaluating evm call event).