### PR TITLE
Dep versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ pytest-asyncio = "^0.19.0"
 click = "^8.1.3"
 pydantic = "^1.10.2"
 python-box = "^7.0.1"
-telliot-feeds = {git = "https://github.com/tellor-io/telliot-feeds", rev = "main"}
-telliot-core = {git = "https://github.com/tellor-io/telliot-core", rev = "main"}
+telliot-feeds = "^0.1.23"
+telliot-core = "^0.3.6"
 lru-dict = "^1.3.0"
 numpy = "^1.21"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ pytest-asyncio = "^0.19.0"
 click = "^8.1.3"
 pydantic = "^1.10.2"
 python-box = "^7.0.1"
-telliot-feeds = "^0.1.19"
+telliot-feeds = {git = "https://github.com/tellor-io/telliot-feeds", rev = "6ce6889fff56bbffa303acd751ed1fb269dd35df"}
+lru-dict = "^1.3.0"
+numpy = "^1.21"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ pytest-asyncio = "^0.19.0"
 click = "^8.1.3"
 pydantic = "^1.10.2"
 python-box = "^7.0.1"
-telliot-feeds = {git = "https://github.com/tellor-io/telliot-feeds", rev = "6ce6889fff56bbffa303acd751ed1fb269dd35df"}
+telliot-feeds = {git = "https://github.com/tellor-io/telliot-feeds", rev = "main"}
+telliot-core = {git = "https://github.com/tellor-io/telliot-core", rev = "main"}
 lru-dict = "^1.3.0"
 numpy = "^1.21"
 


### PR DESCRIPTION
In addition to bumping up the numpy version, made a change to how the DVM installs telliot. For our purposes, Instead of trying to find a version of telliot-feeds and telliot-core that's been pushed to pypi, it should install the latest main branch strait from github. This will save a lot of time. Any concerns?