### PR TITLE
Better Alerts

### DIFF
--- a/src/tellor_disputables/data.py
+++ b/src/tellor_disputables/data.py
@@ -434,7 +434,7 @@ async def parse_new_report_event(
 
     if new_report.query_type == "SpotPrice":
         if len(event_data.args._value) != 32:
-            send_discord_msg("Spot price value length is not 32 bytes")
+            send_discord_msg(f"SpotPrice value not 32 bytes! \n{new_report.link}")
 
     # if query of event matches a query type of the monitored feeds, fill the query parameters
 

--- a/src/tellor_disputables/discord.py
+++ b/src/tellor_disputables/discord.py
@@ -75,7 +75,7 @@ def generate_alert_msg(disputable: bool, link: str) -> str:
 def send_discord_msg(msg: str) -> None:
     """Send Discord alert."""
     MONITOR_NAME = os.getenv("MONITOR_NAME")
-    message = f"{MONITOR_NAME} Found Something:"
+    message = f"❗{MONITOR_NAME} Found Something❗\n"
     get_alert_bot_1().post(content=message + msg)
     try:
         get_alert_bot_2().post(content=message + msg)

--- a/src/tellor_disputables/discord.py
+++ b/src/tellor_disputables/discord.py
@@ -74,14 +74,16 @@ def generate_alert_msg(disputable: bool, link: str) -> str:
 
 def send_discord_msg(msg: str) -> None:
     """Send Discord alert."""
-    get_alert_bot_1().post(content=msg)
+    MONITOR_NAME = os.getenv("MONITOR_NAME")
+    message = f"{MONITOR_NAME} Found Something:"
+    get_alert_bot_1().post(content=message + msg)
     try:
-        get_alert_bot_2().post(content=msg)
+        get_alert_bot_2().post(content=message + msg)
     except Exception as e:
         click.echo(f"alert bot 2 not used? {e}")
         pass
     try:
-        get_alert_bot_3().post(content=msg)
+        get_alert_bot_3().post(content=message + msg)
     except Exception as e:
         click.echo(f"alert bot 3 not used? {e}")
         pass

--- a/vars.example.sh
+++ b/vars.example.sh
@@ -1,3 +1,4 @@
+export MONITOR_NAME="DVM_1" #choose a name for your monitor
 export DISCORD_WEBHOOK_URL_1="https://discord.com/api/webhooks/your_webhook_url"
 export DISCORD_WEBHOOK_URL_2=""
 export DISCORD_WEBHOOK_URL_3=""


### PR DESCRIPTION
### summary:
Two simple changes:
1) DVM power users need to know which one of their processes is sending alerts. Added a configurable MONITOR_NAME that prints with alerts so that you know where they came from.
2) When a SpotPrice value is submitted with less than 32 bytes, the alert now includes the name of the monitor and a link to the transaction!